### PR TITLE
fix: add os-variant and disk size to virt-install

### DIFF
--- a/bin/eimg-wait.in
+++ b/bin/eimg-wait.in
@@ -35,9 +35,12 @@ trap cleanup EXIT
 
 echo "using $workdir"
 
+
 virt-install \
+    --os-variant "fedora37" \
     --name "$eimg_virt_name" \
     --disk "$image" \
+    --disk size=4 \
     --memory=2048 \
     --import \
     --rng /dev/urandom \


### PR DESCRIPTION
New version of virt-install requires to specify os variant (e.g. fedora37). This also means that it will use it's default size which is 20GiB so I overrided it to 4GiB.