### PR TITLE
fix: check if ssh is available for ipv4 that is found

### DIFF
--- a/libexec/eimg-get-ipv4.in
+++ b/libexec/eimg-get-ipv4.in
@@ -21,6 +21,7 @@ Obtain ipv4 address from a given domain; using qemu agent.
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import logging
+import subprocess
 import sys
 
 import libvirt
@@ -67,8 +68,20 @@ def _main():
             if address['type'] != libvirt.VIR_IP_ADDR_TYPE_IPV4:
                 continue
             log.debug("addr for %s is %s", interface, address["addr"])
-            print(address['addr'])
-            sys.exit(0)
+
+            log.debug("waiting for ssh for 120 seconds")
+            process = subprocess.run(
+                ["wait-for-ssh", "--log=debug", "--timeout=60", address['addr']],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+            if process.returncode == 0:
+                log.debug("ssh succeeded for %s", address['addr'])
+                print(address['addr'])
+                sys.exit(0)
+
+            log.error("ssh failed for %s, reason: %s", address['addr'], process.stderr)
 
     if not found:
         log.error("interface found")


### PR DESCRIPTION
When removing package linux-firmware with updated latest kernel package, the `virsh domifaddr` shows 2 interfaces with two IPs and one MAC - the one with MAC has wrong IP - and taht's the one we try to wait for. This hangs forever. However the second works and also by `arp in <MAC>` we get the working IP. But in the python script, blindly trying with timeout the ssh was the easiest and fastest to implement.